### PR TITLE
Handle too long message

### DIFF
--- a/philadelphia/src/main/java/org/jvirtanen/philadelphia/FIXSession.java
+++ b/philadelphia/src/main/java/org/jvirtanen/philadelphia/FIXSession.java
@@ -332,6 +332,9 @@ public class FIXSession implements Closeable {
 
         while (parser.parse(rxBuffer));
 
+        if (rxBuffer.limit() == rxBuffer.capacity())
+            throw new FIXMessageOverflowException("Too long message");
+
         rxBuffer.compact();
 
         lastRxMillis = currentTimeMillis;

--- a/philadelphia/src/test/java/org/jvirtanen/philadelphia/FIXInitiatorTest.java
+++ b/philadelphia/src/test/java/org/jvirtanen/philadelphia/FIXInitiatorTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import static org.jvirtanen.philadelphia.FIXMsgTypes.*;
 import static org.jvirtanen.philadelphia.FIXStatus.*;
 import static org.jvirtanen.philadelphia.FIXTags.*;
+import static org.jvirtanen.philadelphia.Strings.*;
 
 import java.io.IOException;
 import java.nio.channels.ServerSocketChannel;
@@ -316,6 +317,16 @@ public class FIXInitiatorTest {
         Event  status  = new Logout();
 
         acceptorMessageInitiatorStatus(message, status);
+    }
+
+    @Test
+    public void receiveTooLongMessage() throws IOException {
+        exception.expect(FIXMessageOverflowException.class);
+
+        acceptor.send("35=5|34=1|58=" + repeat('A', 1024));
+
+        while (true)
+            initiator.receive();
     }
 
     @Test

--- a/philadelphia/src/test/java/org/jvirtanen/philadelphia/Strings.java
+++ b/philadelphia/src/test/java/org/jvirtanen/philadelphia/Strings.java
@@ -1,0 +1,14 @@
+package org.jvirtanen.philadelphia;
+
+class Strings {
+
+    public static String repeat(char c, int num) {
+        StringBuilder builder = new StringBuilder(num);
+
+        for (int i = 0; i < num; i++)
+            builder.append(c);
+
+        return builder.toString();
+    }
+
+}

--- a/philadelphia/src/test/java/org/jvirtanen/philadelphia/TestSession.java
+++ b/philadelphia/src/test/java/org/jvirtanen/philadelphia/TestSession.java
@@ -21,8 +21,8 @@ class TestSession implements Closeable {
 
         this.parser = new TestMessageParser(listener);
 
-        this.rxBuffer = ByteBuffer.allocate(1024);
-        this.txBuffer = ByteBuffer.allocate(1024);
+        this.rxBuffer = ByteBuffer.allocate(2048);
+        this.txBuffer = ByteBuffer.allocate(2048);
     }
 
     public int receive() throws IOException {


### PR DESCRIPTION
Throw an exception upon an incoming message that is too long to fit into the receive buffer.

Fixes #15.