### PR TITLE
Fixed java.lang.ArrayIndexOutOfBoundsException

### DIFF
--- a/philadelphia/src/main/java/org/jvirtanen/philadelphia/FIXSession.java
+++ b/philadelphia/src/main/java/org/jvirtanen/philadelphia/FIXSession.java
@@ -65,10 +65,10 @@ public class FIXSession implements Closeable {
         this.channel = channel;
 
         this.config = config;
-
-        this.beginString = new FIXValue(8);
-        this.bodyLength  = new FIXValue(8);
-        this.checkSum    = new FIXValue(8);
+        
+        this.beginString = new FIXValue(config.getFieldCapacity());
+        this.bodyLength  = new FIXValue(config.getFieldCapacity());
+        this.checkSum    = new FIXValue(config.getFieldCapacity());
 
         this.beginString.setString(config.getVersion().getBeginString());
 

--- a/philadelphia/src/test/java/org/jvirtanen/philadelphia/FIXConfigTest.java
+++ b/philadelphia/src/test/java/org/jvirtanen/philadelphia/FIXConfigTest.java
@@ -1,0 +1,14 @@
+package org.jvirtanen.philadelphia;
+
+import org.junit.Test;
+
+public class FIXConfigTest {
+    
+    @Test
+    public void beginStringLength() {
+        FIXConfig config = new FIXConfig.Builder()
+                .setVersion(FIXVersion.FIXT_1_1)
+                .build();
+        new FIXSession(null, config, null, null);
+    }
+}


### PR DESCRIPTION
Fixed
<pre>
java.lang.ArrayIndexOutOfBoundsException: 8

	at org.jvirtanen.philadelphia.FIXValue.setString(FIXValue.java:240)
	at org.jvirtanen.philadelphia.FIXSession.<init>(FIXSession.java:73)
	at org.jvirtanen.philadelphia.FIXSession.<init>(FIXSession.java:127)
</pre>
if beginString is FIXT_1_1. (FIXT_1_1 + SOH = 9 bytes) 