### PR TITLE
Support running data reception and transmission on different threads

### DIFF
--- a/philadelphia/src/main/java/org/jvirtanen/philadelphia/FIXSession.java
+++ b/philadelphia/src/main/java/org/jvirtanen/philadelphia/FIXSession.java
@@ -38,8 +38,20 @@ public class FIXSession implements Closeable {
 
     private ByteBuffer[] txBuffers;
 
-    private long lastRxMillis;
+    /*
+     * This variable is written on data reception and read on session
+     * keep-alive. These two functions can run on different threads
+     * without locking.
+     */
+    private volatile long lastRxMillis;
+
+    /*
+     * This variable is written on data transmission and read on session
+     * keep-alive. These two functions can run on different threads but
+     * require locking.
+     */
     private long lastTxMillis;
+
     private long testRequestTxMillis;
 
     private final long heartbeatMillis;

--- a/philadelphia/src/main/java/org/jvirtanen/philadelphia/package-info.java
+++ b/philadelphia/src/main/java/org/jvirtanen/philadelphia/package-info.java
@@ -1,7 +1,19 @@
 /**
  * An implementation of the FIX protocol.
  *
- * <p>The implementation is based on the Java NIO API.</p>
+ * <p>The implementation is based on the Java NIO API and consists of three
+ * primary functions:</p>
+ * <ul>
+ * <li>data reception
+ *   ({@link org.jvirtanen.philadelphia.FIXSession#receive})</li>
+ * <li>data transmission</li>
+ * <li>session keep-alive
+ *   ({@link org.jvirtanen.philadelphia.FIXSession#keepAlive})</li>
+ * </ul>
+ *
+ * <p>Data reception can run on one thread and data transmission and session
+ * keep-alive on another without locking. Data transmission and session
+ * keep-alive can run on different threads but require locking.</p>
  *
  * <p>The underlying socket channels can be either blocking or non-blocking.
  * In both cases, data transmission always blocks.</p>


### PR DESCRIPTION
Based on the model used in the NASDAQ SoupBinTCP 3.00 implementation in [Nassau](https://github.com/jvirtanen/nassau), add support for running data reception and transmission on different threads.